### PR TITLE
Fix grammar to keep root_exprs

### DIFF
--- a/src/parser.pest
+++ b/src/parser.pest
@@ -17,5 +17,5 @@ rpt_expr    =  { opt_expr ~ ("*" ~ opt_expr)? }
 
 lbox_expr   =  { rpt_expr ~ ("#" ~ rpt_expr)? }
 
-root_expr   = _{ lbox_expr+ }
+root_expr   =  { lbox_expr+ }
 input       = _{ root_expr ~ EOI }


### PR DESCRIPTION
Small bugfix for input files with multiple independent expressions.