### PR TITLE
Strip line breaks from CLI and example inputs before compiling

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,19 +22,25 @@ jobs:
       - run: cargo clippy -- -D warnings
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
 
   examples:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo run --example example_diagrams
       - uses: actions/upload-artifact@v4
         with:
-          name: examples
+          name: examples-${{ matrix.os }}
           path: examples/*.html

--- a/examples/example_diagrams.rs
+++ b/examples/example_diagrams.rs
@@ -19,6 +19,7 @@ fn output(outname: &str, style: &railroad::Stylesheet) -> Result<(), io::Error> 
                 println!("Generating from `{}`", filename);
                 let mut buffer = String::new();
                 fs::File::open(path.path())?.read_to_string(&mut buffer)?;
+                buffer = buffer.lines().collect::<String>();
                 let diagram = railroad_dsl::compile(&buffer, style.stylesheet()).unwrap();
                 write!(outp, "<h3>Generated from <i>`{}`</i></h3>", filename)?;
                 write!(

--- a/src/bin/railroad.rs
+++ b/src/bin/railroad.rs
@@ -97,6 +97,7 @@ fn dia_from_stdin(
 
     let mut buf = String::new();
     io::stdin().read_to_string(&mut buf)?;
+    buf = buf.lines().collect::<String>();
     let diagram = railroad_dsl::compile(&buf, css).map_err(|e| Box::new(e.with_path("<stdin>")))?;
     match format {
         Format::SVG => {
@@ -119,7 +120,7 @@ fn dia_from_files(
     let mut err = Ok(());
     for input in inputs {
         let output = PathBuf::from(&input).with_extension(format.file_extension());
-        let buf = match fs::read_to_string(input) {
+        let mut buf = match fs::read_to_string(input) {
             Err(e) => {
                 eprintln!("error reading file {input}: {e}");
                 err = Err(Error::IO(e));
@@ -127,6 +128,7 @@ fn dia_from_files(
             }
             Ok(buf) => buf,
         };
+        buf = buf.lines().collect::<String>();
         let diagram = match railroad_dsl::compile(&buf, css) {
             Err(e) => {
                 eprintln!("syntax error:\n{}", e.clone().with_path(input));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ mod tests {
                         .unwrap()
                         .read_to_string(&mut buffer)
                         .unwrap();
+                    buffer = buffer.lines().collect::<String>();
                     if let Err(e) = compile(&buffer, DEFAULT_CSS) {
                         panic!("Failed to compile {}", e.with_path(filename));
                     }


### PR DESCRIPTION
# Strip line breaks before compiling CLI/example input

## Summary

This PR strips line breaks from input before passing it to `railroad_dsl::compile`.

## What changed

- Strip line breaks from stdin input in `dia_from_stdin`
- Strip line breaks from file input in `dia_from_files`
- Apply the same normalization in `examples/example_diagrams.rs`
- Update tests to use normalized input as well

## Why

This fixes several cases that were failing because of embedded line breaks:

- unit tests could fail
- multiline stdin input could fail
- the example using multiline file input could fail

## Notes

This change removes line breaks entirely by joining all lines into a single string.